### PR TITLE
Soft-fail corrupt media extraction, desktop update restart, accelerator report

### DIFF
--- a/panoptikon-desktop/src-tauri/src/updates.rs
+++ b/panoptikon-desktop/src-tauri/src/updates.rs
@@ -931,9 +931,14 @@ impl UpdateCoordinator {
             return Err(format!("Update installation failed: {error}"));
         }
         emit_progress(app, "restarting", 0, None, true);
+        // On Unix, restart replaces this process and never returns. Windows
+        // completes install without an in-process restart here.
+        #[cfg(windows)]
+        {
+            return Ok(());
+        }
         #[cfg(not(windows))]
         app.restart();
-        Ok(())
     }
 
     async fn validate_exact_install_target(

--- a/panoptikon/AGENTS.md
+++ b/panoptikon/AGENTS.md
@@ -115,7 +115,8 @@ Behavior (important)
   - `POST /api/jobs/data/extraction` validates models and resolves effective `batch_size`/`threshold` at enqueue time (mirrors Python): a bad inference ID fails the request, and queue status shows the resolved values.
   - Threshold semantics mirror Python: a zero threshold anywhere in the chain (request, job settings) means "unset" and falls back to the model default; a still-unset/zero final value is omitted from inference payloads so the server-side fallback (e.g. mcut for taggers) applies.
   - Extraction input handlers render PDFs natively via the shared pdfium binding (all pages, 2x scale) and HTML via the shared headless-browser screenshot path — the same code the scan pipeline uses for thumbnails. Render failures (including pdfium/browser not installed) fail the item so it is retried next run; they never write a placeholder.
-  - Image inputs get a header-level readability check before upload (mirrors Python `is_image_readable`); unreadable files fail the item instead of reaching the inference server where they could fail a coalesced batch.
+  - Image inputs get a **full decode** before upload (not header-only) so pixel-corrupt files soft-fail as `ApiError::input_media` before coalesced inference. Format/decode failures are `ApiError::input_media` (logged with `path` + `sha256`, placeholder with one write retry + short backoff, soft-succeed when placeholder lands). Open/read I/O failures are **not** soft-failed (`ApiError::internal`) so transient mount/NFS issues do not permanent-skip the item. If both placeholder attempts fail after input_media, the error is counted as **systemic** (not input-media) and the item task returns `Err`, so a DB/write outage cannot soft-complete as pure corrupt media. When every attempted item fails only on input media (and placeholders landed), the job completes with a warning instead of "check the inference server". Job-level total failure is reserved for all-failed runs that include at least one non-input (inference/output/placeholder-write) error. Classification is pure (`classify_extraction_job_failure`); unit + DB integration tests cover it.
+  - Every extraction item failure log includes `path` and `sha256`.
   - Sliced image inputs are re-encoded in their source format (PNG stays PNG with alpha; unknown formats fall back to PNG); JPEG slices keep the quality-85 encoder. PDF pages and HTML screenshots are sliced using their own rendered dimensions, other frames use the item's stored dimensions.
   - Tag output text entries keep Python's ordering: namespaces in first-appearance order, tags confidence-sorted within each namespace. Empty `metadata` objects produce no metadata text entry.
   - `data_log` start and end times use the same local-time format (`db::extraction_write::current_iso_timestamp`), and incomplete-job cleanup runs before the remaining count so `[jobs].atomic_extraction_jobs` cleanup is reflected in it.
@@ -127,6 +128,16 @@ Behavior (important)
   - `PUT /api/jobs/config` rejects unparseable `cron_schedule` strings with 400 (Python accepts them and fails silently in the ticker). `GET /api/jobs/cronjob/schedule` (additive, not in Python) reports enabled/valid/next_run/last_run.
   - Embedding-model preload (`preload_embedding_models`) runs on the same minute tick, mirroring Python: existing text-embedding/clip setters (excluding `tclip/`) are kept loaded under cache key `preload[<index_db>]` with 1h TTL and renewal ~2 minutes before expiry; disabling clears the inference cache once.
   - System config parses `job_filters` and `filescan_filter` as PQL objects; invalid PQL in config fails to load (mirrors Python).
+- Accelerator report (`panoptikon/src/accelerator_report.rs`): at server and
+  `inferio` startup (and via `panoptikon accelerator`) we always log the
+  resolved inference **backend** (`cpu` / `cuda` / `rocm`, extensible) and any
+  detected GPU names. Backend priority: managed-venv sentinel →
+  `PANOPTIKON_ACCELERATOR` (Nix wrap) → config/`auto` host probes. GPU stacks
+  are pluggable probes (NVIDIA + AMD/ROCm today; add Intel XPU etc. later).
+  ROCm device names prefer `rocm-smi`; fallback `rocminfo` keeps only agents
+  with `Device Type: GPU` (CPU agents also have a Marketing Name and must not
+  be listed as devices). **CPU** backend is logged as using CPU (no warning).
+  A **GPU** backend with no device name yields a **warning**, not a failure.
 - Accelerator env (`panoptikon/src/accelerator_env.rs`): workers get host
   HIP/HSA on `LD_LIBRARY_PATH` only when the **installed** accelerator is
   `rocm` — read from the setup sentinel's `extra=` line

--- a/panoptikon/src/accelerator_report.rs
+++ b/panoptikon/src/accelerator_report.rs
@@ -1,0 +1,680 @@
+//! Runtime accelerator / GPU diagnostics for logs and `panoptikon accelerator`.
+//!
+//! Two independent facts:
+//!
+//! 1. **Backend** — which inference stack we use (`cpu` / `cuda` / `rocm`, …).
+//!    Always resolvable. Priority: managed-venv sentinel →
+//!    [`ACCELERATOR_ENV`] (Nix wrap) → config / `auto` host probes.
+//! 2. **Devices** — optional marketing names from pluggable **stack probes**
+//!    (NVIDIA, AMD/ROCm today). Append to [`GPU_STACK_PROBES`] for new stacks
+//!    (e.g. Intel XPU); add an [`Accelerator`] variant when the managed venv
+//!    gains a matching extra.
+//!
+//! **Warnings:** only when a *GPU* backend is selected but no device name is
+//! found. **CPU is never a warning** — it is reported as using CPU.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::config::{Accelerator, Settings};
+use crate::setup::{installed_accelerator, resolve_accelerator};
+
+/// Env var set by the Nix package wrap (and optionally by operators).
+pub const ACCELERATOR_ENV: &str = "PANOPTIKON_ACCELERATOR";
+
+/// One named GPU/accelerator device from a hardware stack probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuDevice {
+    /// Stack id (`nvidia`, `amd-rocm`, future `intel-xpu`, …).
+    pub stack: &'static str,
+    pub name: String,
+}
+
+/// Presence of one GPU software stack on the host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuStackPresence {
+    pub stack: &'static str,
+    /// Backend this stack typically drives (never `auto`).
+    pub backend: Accelerator,
+    pub devices: Vec<GpuDevice>,
+    pub evidence: String,
+}
+
+/// Where the resolved backend came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendSource {
+    /// Setup sentinel `extra=` (installed torch wheels).
+    InstalledVenv,
+    /// [`ACCELERATOR_ENV`] (e.g. Nix `-cuda` / `-rocm` wrap).
+    EnvPin,
+    /// Config / CLI (including `auto` after host probes).
+    ConfigOrProbe { evidence: String },
+}
+
+impl BackendSource {
+    pub fn label(&self) -> String {
+        match self {
+            Self::InstalledVenv => "managed venv (setup sentinel)".into(),
+            Self::EnvPin => format!("{ACCELERATOR_ENV} environment pin"),
+            Self::ConfigOrProbe { evidence } => evidence.clone(),
+        }
+    }
+}
+
+/// Full diagnostic snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcceleratorReport {
+    /// Resolved backend; never [`Accelerator::Auto`] after resolve.
+    pub backend: Accelerator,
+    pub backend_source: BackendSource,
+    pub stacks: Vec<GpuStackPresence>,
+    pub warnings: Vec<String>,
+}
+
+impl AcceleratorReport {
+    /// Devices belonging to the stack that matches the selected GPU backend.
+    pub fn selected_devices(&self) -> Vec<&GpuDevice> {
+        let Some(stack_id) = stack_id_for_backend(self.backend) else {
+            return Vec::new();
+        };
+        self.stacks
+            .iter()
+            .filter(|s| s.stack == stack_id)
+            .flat_map(|s| s.devices.iter())
+            .collect()
+    }
+
+    /// Multi-line human text for CLI / package tests.
+    pub fn format_text(&self) -> String {
+        let mut lines = vec![format!(
+            "accelerator backend: {} ({})",
+            accelerator_slug(self.backend),
+            self.backend_source.label()
+        )];
+
+        if is_gpu_backend(self.backend) {
+            let devices = self.selected_devices();
+            if devices.is_empty() {
+                lines.push("GPU devices: (none detected)".into());
+            } else {
+                lines.push("GPU devices:".into());
+                for d in devices {
+                    lines.push(format!("  - [{}] {}", d.stack, d.name));
+                }
+            }
+        } else {
+            // CPU is a normal outcome — never a warning.
+            lines.push("using CPU (no GPU accelerator selected)".into());
+            let other: Vec<&GpuDevice> = self
+                .stacks
+                .iter()
+                .flat_map(|s| s.devices.iter())
+                .collect();
+            if !other.is_empty() {
+                lines.push("GPU devices present on host (not selected):".into());
+                for d in other {
+                    lines.push(format!("  - [{}] {}", d.stack, d.name));
+                }
+            }
+        }
+
+        for w in &self.warnings {
+            lines.push(format!("warning: {w}"));
+        }
+        lines.join("\n")
+    }
+}
+
+/// Whether this backend is a GPU stack (may warn if devices are missing).
+pub fn is_gpu_backend(a: Accelerator) -> bool {
+    matches!(a, Accelerator::Cuda | Accelerator::Rocm)
+    // | Accelerator::Xpu
+}
+
+/// Stack probe id for a GPU backend (`nvidia` ↔ cuda, `amd-rocm` ↔ rocm).
+pub fn stack_id_for_backend(a: Accelerator) -> Option<&'static str> {
+    match a {
+        Accelerator::Cuda => Some("nvidia"),
+        Accelerator::Rocm => Some("amd-rocm"),
+        // Accelerator::Xpu => Some("intel-xpu"),
+        Accelerator::Cpu | Accelerator::Auto => None,
+    }
+}
+
+/// Canonical lowercase slug for logs, wrap env, and tests.
+pub fn accelerator_slug(a: Accelerator) -> &'static str {
+    match a {
+        Accelerator::Auto => "auto",
+        Accelerator::Cuda => "cuda",
+        Accelerator::Rocm => "rocm",
+        Accelerator::Cpu => "cpu",
+        // Accelerator::Xpu => "xpu",
+    }
+}
+
+/// Parse wrap env / CLI-style names. Unknown → `None`.
+pub fn parse_accelerator_slug(s: &str) -> Option<Accelerator> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "cpu" => Some(Accelerator::Cpu),
+        "cuda" => Some(Accelerator::Cuda),
+        "rocm" => Some(Accelerator::Rocm),
+        // "xpu" => Some(Accelerator::Xpu),
+        "auto" => Some(Accelerator::Auto),
+        _ => None,
+    }
+}
+
+/// Resolve which backend we use (always concrete). Reads process state.
+pub fn resolve_backend(requested: Accelerator) -> (Accelerator, BackendSource) {
+    resolve_backend_from(
+        requested,
+        installed_accelerator(),
+        std::env::var(ACCELERATOR_ENV).ok().as_deref(),
+    )
+}
+
+/// Pure resolver (unit-tested).
+///
+/// Priority: installed venv → env pin → config/`auto` probes.
+pub fn resolve_backend_from(
+    requested: Accelerator,
+    installed: Option<Accelerator>,
+    env_pin: Option<&str>,
+) -> (Accelerator, BackendSource) {
+    if let Some(installed) = installed {
+        return (installed, BackendSource::InstalledVenv);
+    }
+    if let Some(raw) = env_pin {
+        if let Some(parsed) = parse_accelerator_slug(raw) {
+            if parsed != Accelerator::Auto {
+                return (parsed, BackendSource::EnvPin);
+            }
+        }
+    }
+    match resolve_accelerator(requested) {
+        Ok((backend, evidence)) => (backend, BackendSource::ConfigOrProbe { evidence }),
+        Err(_) => (
+            match requested {
+                Accelerator::Auto => Accelerator::Cpu,
+                other => other,
+            },
+            BackendSource::ConfigOrProbe {
+                evidence: "fallback after resolve error".into(),
+            },
+        ),
+    }
+}
+
+/// Build a report from live config + host probes.
+pub fn build_report(settings: &Settings) -> AcceleratorReport {
+    let (backend, backend_source) =
+        resolve_backend(settings.inference_local.python_env.accelerator);
+    assemble_report(backend, backend_source, probe_gpu_stacks())
+}
+
+/// Pure assembly of warnings + device list (unit-tested).
+pub fn assemble_report(
+    backend: Accelerator,
+    backend_source: BackendSource,
+    stacks: Vec<GpuStackPresence>,
+) -> AcceleratorReport {
+    let mut warnings = Vec::new();
+
+    if let Some(stack_id) = stack_id_for_backend(backend) {
+        let named = stacks
+            .iter()
+            .filter(|s| s.stack == stack_id)
+            .any(|s| !s.devices.is_empty());
+        if !named {
+            let slug = accelerator_slug(backend);
+            warnings.push(format!(
+                "backend is {slug} but no GPU name could be detected for stack \
+                 '{stack_id}' (is the vendor tool on PATH and a device visible?)"
+            ));
+        }
+    }
+
+    AcceleratorReport {
+        backend,
+        backend_source,
+        stacks,
+        warnings,
+    }
+}
+
+/// Log via tracing (server / inferio startup).
+pub fn log_report(settings: &Settings) {
+    let report = build_report(settings);
+    let devices: Vec<String> = if is_gpu_backend(report.backend) {
+        report
+            .selected_devices()
+            .iter()
+            .map(|d| format!("{}:{}", d.stack, d.name))
+            .collect()
+    } else {
+        report
+            .stacks
+            .iter()
+            .flat_map(|s| s.devices.iter())
+            .map(|d| format!("{}:{}", d.stack, d.name))
+            .collect()
+    };
+    let slug = accelerator_slug(report.backend);
+    if is_gpu_backend(report.backend) {
+        tracing::info!(
+            backend = slug,
+            backend_source = %report.backend_source.label(),
+            devices = ?devices,
+            "accelerator backend"
+        );
+    } else {
+        tracing::info!(
+            backend = slug,
+            backend_source = %report.backend_source.label(),
+            devices = ?devices,
+            "accelerator backend: using CPU"
+        );
+    }
+    for w in &report.warnings {
+        tracing::warn!("{w}");
+    }
+}
+
+/// Print to stdout (`panoptikon accelerator`).
+pub fn print_report(settings: &Settings) {
+    println!("{}", build_report(settings).format_text());
+}
+
+// --- GPU stack probes (append new stacks to the list) -------------------------
+
+type StackProbeFn = fn() -> Option<GpuStackPresence>;
+
+const GPU_STACK_PROBES: &[StackProbeFn] = &[probe_nvidia_stack, probe_amd_rocm_stack];
+
+fn probe_gpu_stacks() -> Vec<GpuStackPresence> {
+    GPU_STACK_PROBES.iter().filter_map(|p| p()).collect()
+}
+
+fn probe_nvidia_stack() -> Option<GpuStackPresence> {
+    let mut evidence = Vec::new();
+    if which("nvidia-smi").is_some() {
+        evidence.push("nvidia-smi on PATH");
+    }
+    if cfg!(target_os = "linux") && std::path::Path::new("/proc/driver/nvidia").exists() {
+        evidence.push("/proc/driver/nvidia exists");
+    }
+    if cfg!(windows)
+        && std::env::var_os("SystemRoot")
+            .map(|root| PathBuf::from(root).join("System32/nvidia-smi.exe").is_file())
+            .unwrap_or(false)
+    {
+        evidence.push(r"System32\nvidia-smi.exe exists");
+    }
+    if evidence.is_empty() {
+        return None;
+    }
+    Some(GpuStackPresence {
+        stack: "nvidia",
+        backend: Accelerator::Cuda,
+        devices: nvidia_device_names()
+            .into_iter()
+            .map(|name| GpuDevice {
+                stack: "nvidia",
+                name,
+            })
+            .collect(),
+        evidence: evidence.join("; "),
+    })
+}
+
+fn probe_amd_rocm_stack() -> Option<GpuStackPresence> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+    let mut evidence = Vec::new();
+    if std::path::Path::new("/opt/rocm").is_dir() {
+        evidence.push("/opt/rocm exists");
+    }
+    if which("rocm-smi").is_some() {
+        evidence.push("rocm-smi on PATH");
+    }
+    if which("rocminfo").is_some() {
+        evidence.push("rocminfo on PATH");
+    }
+    if evidence.is_empty() {
+        return None;
+    }
+    Some(GpuStackPresence {
+        stack: "amd-rocm",
+        backend: Accelerator::Rocm,
+        devices: amd_device_names()
+            .into_iter()
+            .map(|name| GpuDevice {
+                stack: "amd-rocm",
+                name,
+            })
+            .collect(),
+        evidence: evidence.join("; "),
+    })
+}
+
+fn nvidia_device_names() -> Vec<String> {
+    let Some(bin) = which("nvidia-smi") else {
+        return Vec::new();
+    };
+    let output = match Command::new(bin)
+        .args(["--query-gpu=name", "--format=csv,noheader"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn amd_device_names() -> Vec<String> {
+    if let Some(names) = rocm_smi_product_names() {
+        if !names.is_empty() {
+            return names;
+        }
+    }
+    rocminfo_marketing_names()
+}
+
+fn rocm_smi_product_names() -> Option<Vec<String>> {
+    let bin = which("rocm-smi")?;
+    let output = Command::new(bin)
+        .args(["--showproductname"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut names = Vec::new();
+    for line in text.lines() {
+        let lower = line.to_ascii_lowercase();
+        for key in ["card series:", "card model:"] {
+            if let Some(idx) = lower.find(key) {
+                let v = line[idx + key.len()..].trim();
+                if !v.is_empty() {
+                    names.push(v.to_string());
+                }
+            }
+        }
+    }
+    Some(names)
+}
+
+fn rocminfo_marketing_names() -> Vec<String> {
+    let Some(bin) = which("rocminfo") else {
+        return Vec::new();
+    };
+    let output = match Command::new(bin).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    parse_rocminfo_gpu_marketing_names(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Collect marketing names only for **GPU** agents.
+///
+/// `rocminfo` prints a `Marketing Name` for every HSA agent, including the
+/// host CPU (usually listed first). Naively taking every Marketing Name line
+/// reports "CPU then GPU" under the ROCm stack even when only the GPU is used
+/// for inference. Fields may appear in either order within an agent block;
+/// agent blocks are separated by lines of asterisks.
+fn parse_rocminfo_gpu_marketing_names(text: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut marketing: Option<String> = None;
+    let mut device_type: Option<String> = None;
+
+    let flush = |marketing: &mut Option<String>,
+                 device_type: &mut Option<String>,
+                 names: &mut Vec<String>| {
+        let name = marketing.take();
+        let dtype = device_type.take();
+        if let (Some(name), Some(dtype)) = (name, dtype) {
+            if dtype.eq_ignore_ascii_case("GPU")
+                && !name.is_empty()
+                && !name.eq_ignore_ascii_case("N/A")
+            {
+                names.push(name);
+            }
+        }
+    };
+
+    for line in text.lines() {
+        let t = line.trim();
+        // Agent separator: "*******" (rocminfo) between Agent blocks.
+        if !t.is_empty() && t.chars().all(|c| c == '*') {
+            flush(&mut marketing, &mut device_type, &mut names);
+            continue;
+        }
+        if let Some(rest) = t.strip_prefix("Marketing Name:") {
+            marketing = Some(rest.trim().to_string());
+            continue;
+        }
+        if let Some(rest) = t.strip_prefix("Device Type:") {
+            device_type = Some(rest.trim().to_string());
+            continue;
+        }
+    }
+    flush(&mut marketing, &mut device_type, &mut names);
+    names
+}
+
+fn which(name: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths).find_map(|dir| {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+            let with_exe = dir.join(format!("{name}.exe"));
+            with_exe.is_file().then_some(with_exe)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_stacks() -> Vec<GpuStackPresence> {
+        Vec::new()
+    }
+
+    fn nvidia_named() -> Vec<GpuStackPresence> {
+        vec![GpuStackPresence {
+            stack: "nvidia",
+            backend: Accelerator::Cuda,
+            devices: vec![GpuDevice {
+                stack: "nvidia",
+                name: "Test GPU".into(),
+            }],
+            evidence: "test".into(),
+        }]
+    }
+
+    #[test]
+    fn slug_and_parse_round_trip() {
+        for a in [Accelerator::Cpu, Accelerator::Cuda, Accelerator::Rocm] {
+            assert_eq!(parse_accelerator_slug(accelerator_slug(a)), Some(a));
+        }
+        assert_eq!(parse_accelerator_slug("CUDA"), Some(Accelerator::Cuda));
+        assert_eq!(parse_accelerator_slug("nope"), None);
+    }
+
+    #[test]
+    fn format_text_cpu_no_devices() {
+        let report = assemble_report(
+            Accelerator::Cpu,
+            BackendSource::ConfigOrProbe {
+                evidence: "no NVIDIA or ROCm evidence found".into(),
+            },
+            empty_stacks(),
+        );
+        let text = report.format_text();
+        assert!(text.contains("accelerator backend: cpu"), "{text}");
+        assert!(
+            text.contains("using CPU (no GPU accelerator selected)"),
+            "{text}"
+        );
+        assert!(!text.contains("warning:"), "{text}");
+        assert!(!text.contains("none detected"), "{text}");
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn format_text_cuda_with_device() {
+        let report = assemble_report(Accelerator::Cuda, BackendSource::EnvPin, nvidia_named());
+        let text = report.format_text();
+        assert!(text.contains("backend: cuda"), "{text}");
+        assert!(text.contains(ACCELERATOR_ENV), "{text}");
+        assert!(text.contains("[nvidia] Test GPU"), "{text}");
+        assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn cuda_without_devices_warns() {
+        let report = assemble_report(Accelerator::Cuda, BackendSource::EnvPin, empty_stacks());
+        assert_eq!(report.backend, Accelerator::Cuda);
+        assert_eq!(report.warnings.len(), 1);
+        assert!(report.warnings[0].contains("cuda"));
+        assert!(report.format_text().contains("warning:"));
+    }
+
+    #[test]
+    fn rocm_without_devices_warns() {
+        let report = assemble_report(Accelerator::Rocm, BackendSource::EnvPin, empty_stacks());
+        assert_eq!(report.backend, Accelerator::Rocm);
+        assert!(report.warnings.iter().any(|w| w.contains("rocm")));
+    }
+
+    #[test]
+    fn cpu_with_host_gpu_is_not_a_warning() {
+        let report = assemble_report(
+            Accelerator::Cpu,
+            BackendSource::ConfigOrProbe {
+                evidence: "explicitly configured".into(),
+            },
+            nvidia_named(),
+        );
+        assert!(report.warnings.is_empty(), "{:?}", report.warnings);
+        let text = report.format_text();
+        assert!(text.contains("using CPU"), "{text}");
+        assert!(text.contains("not selected"), "{text}");
+        assert!(text.contains("Test GPU"), "{text}");
+        assert!(!text.contains("warning:"), "{text}");
+    }
+
+    #[test]
+    fn env_pin_overrides_config_when_no_sentinel() {
+        let (backend, source) = resolve_backend_from(Accelerator::Cpu, None, Some("cuda"));
+        assert_eq!(backend, Accelerator::Cuda);
+        assert_eq!(source, BackendSource::EnvPin);
+    }
+
+    #[test]
+    fn installed_venv_wins_over_env_pin() {
+        let (backend, source) =
+            resolve_backend_from(Accelerator::Cuda, Some(Accelerator::Rocm), Some("cuda"));
+        assert_eq!(backend, Accelerator::Rocm);
+        assert_eq!(source, BackendSource::InstalledVenv);
+    }
+
+    #[test]
+    fn stack_id_mapping() {
+        assert_eq!(stack_id_for_backend(Accelerator::Cuda), Some("nvidia"));
+        assert_eq!(stack_id_for_backend(Accelerator::Rocm), Some("amd-rocm"));
+        assert_eq!(stack_id_for_backend(Accelerator::Cpu), None);
+        assert!(!is_gpu_backend(Accelerator::Cpu));
+        assert!(is_gpu_backend(Accelerator::Cuda));
+    }
+
+    /// Minimal rocminfo-shaped output: CPU agent first, then GPU (real tools
+    /// list both Marketing Names; we must keep only Device Type GPU).
+    #[test]
+    fn rocminfo_skips_cpu_agent_marketing_name() {
+        let sample = r#"
+ROCm System Management Interface
+===============================
+*******                      
+Agent 1                      
+*******                      
+  Name:                    AMD Ryzen 9 7950X 16-Core Processor
+  Uuid:                    CPU-XX                             
+  Marketing Name:          AMD Ryzen 9 7950X 16-Core Processor
+  Vendor Name:             CPU                                
+  Feature:                 None specified                     
+  Profile:                 FULL_PROFILE                       
+  Float Round Mode:        NEAR                               
+  Max Queue Number:         0(0x0)                             
+  Queue Min Size:           0(0x0)                             
+  Queue Max Size:           0(0x0)                             
+  Queue Type:              MULTI                              
+  Node:                    0                                  
+  Device Type:             CPU                                
+*******                      
+Agent 2                      
+*******                      
+  Name:                    gfx1100                            
+  Uuid:                    GPU-XX                             
+  Marketing Name:          Radeon RX 7900 XTX                 
+  Vendor Name:             AMD                                
+  Feature:                 KERNEL_DISPATCH                    
+  Profile:                 BASE_PROFILE                       
+  Float Round Mode:        NEAR                               
+  Max Queue Number:         128(0x80)                          
+  Queue Min Size:           64(0x40)                           
+  Queue Max Size:           131072(0x20000)                    
+  Queue Type:              MULTI                              
+  Node:                    1                                  
+  Device Type:             GPU                                
+"#;
+        let names = parse_rocminfo_gpu_marketing_names(sample);
+        assert_eq!(names, vec!["Radeon RX 7900 XTX".to_string()]);
+    }
+
+    /// Device Type may appear before Marketing Name within an agent block.
+    #[test]
+    fn rocminfo_accepts_device_type_before_marketing_name() {
+        let sample = r#"
+*******
+Agent 1
+*******
+  Device Type:             GPU
+  Marketing Name:          Radeon RX 6800 XT
+*******
+Agent 2
+*******
+  Device Type:             CPU
+  Marketing Name:          Some CPU
+"#;
+        let names = parse_rocminfo_gpu_marketing_names(sample);
+        assert_eq!(names, vec!["Radeon RX 6800 XT".to_string()]);
+    }
+
+    #[test]
+    fn rocminfo_drops_na_and_empty_gpu_names() {
+        let sample = r#"
+*******
+  Device Type:             GPU
+  Marketing Name:          N/A
+*******
+  Marketing Name:          
+  Device Type:             GPU
+*******
+  Marketing Name:          Real GPU
+  Device Type:             GPU
+"#;
+        let names = parse_rocminfo_gpu_marketing_names(sample);
+        assert_eq!(names, vec!["Real GPU".to_string()]);
+    }
+}

--- a/panoptikon/src/api_error.rs
+++ b/panoptikon/src/api_error.rs
@@ -5,10 +5,23 @@ use axum::{
 };
 use serde::Serialize;
 
+/// Classifies errors so jobs can treat per-item bad media differently from
+/// systemic inference failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ApiErrorKind {
+    #[default]
+    Generic,
+    /// Corrupt/unreadable *payload* for one item (decode/format). Open/read
+    /// I/O uses [`ApiError::internal`] so transient mount failures are not
+    /// permanent-skipped via placeholder.
+    InputMedia,
+}
+
 #[derive(Debug)]
 pub struct ApiError {
     status: StatusCode,
     detail: String,
+    kind: ApiErrorKind,
 }
 
 impl ApiError {
@@ -16,6 +29,7 @@ impl ApiError {
         Self {
             status,
             detail: detail.into(),
+            kind: ApiErrorKind::Generic,
         }
     }
 
@@ -29,6 +43,24 @@ impl ApiError {
 
     pub fn internal(detail: impl Into<String>) -> Self {
         Self::new(StatusCode::INTERNAL_SERVER_ERROR, detail)
+    }
+
+    /// Per-item media failure: log + count as error, do not treat as job-wide
+    /// inference outage when every remaining item is bad data.
+    pub fn input_media(detail: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: detail.into(),
+            kind: ApiErrorKind::InputMedia,
+        }
+    }
+
+    pub fn is_input_media(&self) -> bool {
+        self.kind == ApiErrorKind::InputMedia
+    }
+
+    pub fn detail(&self) -> &str {
+        &self.detail
     }
 }
 
@@ -46,5 +78,25 @@ impl IntoResponse for ApiError {
             detail: self.detail,
         });
         (self.status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_media_is_classified() {
+        let err = ApiError::input_media("corrupt gif");
+        assert!(err.is_input_media());
+        assert_eq!(err.detail(), "corrupt gif");
+    }
+
+    #[test]
+    fn generic_constructors_are_not_input_media() {
+        assert!(!ApiError::internal("inference down").is_input_media());
+        assert!(!ApiError::bad_request("bad arg").is_input_media());
+        assert!(!ApiError::not_found("missing").is_input_media());
+        assert!(!ApiError::new(StatusCode::BAD_GATEWAY, "proxy").is_input_media());
     }
 }

--- a/panoptikon/src/jobs/extraction.rs
+++ b/panoptikon/src/jobs/extraction.rs
@@ -65,6 +65,7 @@ pub(crate) struct ModelMetadata {
 }
 
 #[derive(Debug, Clone)]
+#[derive(Default)]
 struct JobInputData {
     file_id: i64,
     item_id: i64,
@@ -107,6 +108,11 @@ struct JobCounters {
     other_files: i64,
     total_segments: i64,
     errors: i64,
+    /// Subset of `errors` caused by unreadable/corrupt source media (input
+    /// path), not by inference. When every attempted item fails but all
+    /// failures are input-side, the job completes with errors rather than
+    /// being treated as a systemic inference outage.
+    input_errors: i64,
     data_load_time: PhaseTimer,
     inference_time: PhaseTimer,
 }
@@ -335,8 +341,13 @@ async fn run_extraction_job_inner(
                 total_remaining,
             )
             .await;
+            // process_item logs path/sha256 on every failure; soft input-media
+            // failures return Ok after counting the error.
             if let Err(err) = result {
-                tracing::error!(error = ?err, "extraction item failed");
+                tracing::error!(
+                    error = %err.detail(),
+                    "extraction item task returned error"
+                );
             }
         });
     }
@@ -353,13 +364,14 @@ async fn run_extraction_job_inner(
         remaining
     };
 
-    let (final_update, total_failure) = {
+    let (final_update, failure_kind) = {
         let guard = counters.lock().await;
-        // Every attempted item failing means a systemic cause (inference
-        // server down, model broken), not per-item bad data: surface it as a
-        // job failure instead of a "completed" job that did nothing. The
-        // log row is left unfinished so the cleanup pass marks it incomplete.
-        let total_failure = guard.processed > 0 && guard.errors >= guard.processed;
+        let failure_kind = classify_extraction_job_failure(
+            guard.processed,
+            guard.errors,
+            guard.input_errors,
+        );
+        let total_failure = matches!(failure_kind, ExtractionJobFailureKind::Systemic);
         let update = DataLogUpdate {
             image_files: guard.image_files,
             video_files: guard.video_files,
@@ -378,9 +390,12 @@ async fn run_extraction_job_inner(
             data_load_work_secs = guard.data_load_time.work_secs(),
             inference_busy_secs = guard.inference_time.busy_secs(),
             inference_work_secs = guard.inference_time.work_secs(),
+            errors = guard.errors,
+            input_errors = guard.input_errors,
+            ?failure_kind,
             "extraction job phase timing"
         );
-        (update, total_failure)
+        (update, failure_kind)
     };
     let _ = call_index_db_writer(&job.index_db, |reply| IndexDbWriterMessage::UpdateDataLog {
         job_id,
@@ -394,11 +409,20 @@ async fn run_extraction_job_inner(
         .unload_model_all(&model.setter_name, CACHE_KEY)
         .await;
 
-    if total_failure {
-        return Err(ApiError::internal(format!(
-            "All {} attempted items failed; check the inference server",
-            final_update.errors
-        )));
+    match failure_kind {
+        ExtractionJobFailureKind::Systemic => {
+            return Err(ApiError::internal(format!(
+                "All {} attempted items failed; check the inference server",
+                final_update.errors
+            )));
+        }
+        ExtractionJobFailureKind::InputMediaOnly => {
+            tracing::warn!(
+                errors = final_update.errors,
+                "extraction completed: every attempted item failed on input media (corrupt/unreadable files); not treating as inference outage"
+            );
+        }
+        ExtractionJobFailureKind::None => {}
     }
     Ok(())
 }
@@ -457,12 +481,36 @@ async fn process_item(
     total_remaining: i64,
 ) -> ApiResult<()> {
     let item_type = item.item_type.clone();
+    let path = item.path.clone();
+    let sha256 = item.sha256.clone();
     let load_span = counters.lock().await.data_load_time.start();
     let prepare_result = input_handlers::prepare_item(index_db, model, item).await;
     drop(load_span);
     let prepared = match prepare_result {
         Ok(prepared) => prepared,
         Err(err) => {
+            tracing::error!(
+                error = %err.detail(),
+                path = %path,
+                sha256 = %sha256,
+                input_media = err.is_input_media(),
+                "extraction item failed"
+            );
+            // Soft-fail unreadable/corrupt media: write a placeholder so the
+            // item is not re-selected every cron run, count the error, continue.
+            if err.is_input_media() {
+                return soft_fail_input_media(
+                    index_db,
+                    model,
+                    job_id,
+                    &path,
+                    &sha256,
+                    &item_type,
+                    counters,
+                    total_remaining,
+                )
+                .await;
+            }
             finalize_item(
                 index_db,
                 job_id,
@@ -470,6 +518,7 @@ async fn process_item(
                 0,
                 false,
                 true,
+                false,
                 counters,
                 total_remaining,
             )
@@ -481,6 +530,14 @@ async fn process_item(
     if prepared.inputs.is_empty() {
         let result =
             output_handlers::write_placeholder(index_db, model, job_id, &prepared.item).await;
+        if let Err(ref err) = result {
+            tracing::error!(
+                error = %err.detail(),
+                path = %prepared.item.path,
+                sha256 = %prepared.item.sha256,
+                "extraction item failed"
+            );
+        }
         finalize_item(
             index_db,
             job_id,
@@ -488,6 +545,7 @@ async fn process_item(
             0,
             result.is_ok(),
             result.is_err(),
+            false,
             counters,
             total_remaining,
         )
@@ -531,6 +589,12 @@ async fn process_item(
         Ok(outputs) => outputs,
         Err(err) => {
             let api_err = ApiError::internal(format!("Inference failed: {err}"));
+            tracing::error!(
+                error = %api_err.detail(),
+                path = %prepared.item.path,
+                sha256 = %prepared.item.sha256,
+                "extraction item failed"
+            );
             finalize_item(
                 index_db,
                 job_id,
@@ -538,6 +602,7 @@ async fn process_item(
                 segments,
                 false,
                 true,
+                false,
                 counters,
                 total_remaining,
             )
@@ -549,6 +614,14 @@ async fn process_item(
     let result =
         output_handlers::handle_outputs(index_db, model, job_id, prepared.item.clone(), outputs)
             .await;
+    if let Err(ref err) = result {
+        tracing::error!(
+            error = %err.detail(),
+            path = %prepared.item.path,
+            sha256 = %prepared.item.sha256,
+            "extraction item failed"
+        );
+    }
     finalize_item(
         index_db,
         job_id,
@@ -556,6 +629,7 @@ async fn process_item(
         segments,
         result.is_ok(),
         result.is_err(),
+        false,
         counters,
         total_remaining,
     )
@@ -642,6 +716,147 @@ fn merge_outputs(first: PredictOutput, second: PredictOutput) -> anyhow::Result<
     }
 }
 
+/// Soft-fail path for unreadable/corrupt source media: write a placeholder
+/// (retry once on write failure), count as an input-media error, and continue
+/// the job. Returns `Ok(())` only when the placeholder lands so the item is
+/// not re-selected every cron. If both write attempts fail, the failure is
+/// counted as **systemic** (not input-media) so a DB/write outage cannot soft-
+/// complete as "all corrupt media"; `Err` is returned so the failure is not silent.
+async fn soft_fail_input_media(
+    index_db: &str,
+    model: &ModelMetadata,
+    job_id: i64,
+    path: &str,
+    sha256: &str,
+    item_type: &str,
+    counters: Arc<Mutex<JobCounters>>,
+    total_remaining: i64,
+) -> ApiResult<()> {
+    // prepare_item consumed `item`; placeholder writer keys on sha256.
+    let placeholder_item = JobInputData {
+        path: path.to_string(),
+        sha256: sha256.to_string(),
+        item_type: item_type.to_string(),
+        ..Default::default()
+    };
+
+    let mut last_ph_err: Option<ApiError> = None;
+    for attempt in 0..2 {
+        match output_handlers::write_placeholder(index_db, model, job_id, &placeholder_item).await
+        {
+            Ok(_) => {
+                finalize_item(
+                    index_db,
+                    job_id,
+                    item_type,
+                    0,
+                    false,
+                    true,
+                    true,
+                    counters,
+                    total_remaining,
+                )
+                .await;
+                return Ok(());
+            }
+            Err(ph_err) => {
+                tracing::error!(
+                    error = %ph_err.detail(),
+                    path = %path,
+                    sha256 = %sha256,
+                    attempt,
+                    "failed to write placeholder after input media error"
+                );
+                last_ph_err = Some(ph_err);
+                // Brief backoff before the second attempt (writer contention / SQLITE_BUSY).
+                if attempt == 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        }
+    }
+
+    // Placeholder never landed: count as systemic (is_input_error = false) so
+    // a write/DB outage cannot soft-complete as InputMediaOnly. Surface Err.
+    finalize_item(
+        index_db,
+        job_id,
+        item_type,
+        0,
+        false,
+        true,
+        false,
+        counters,
+        total_remaining,
+    )
+    .await;
+    Err(last_ph_err.unwrap_or_else(|| {
+        ApiError::internal("Failed to write placeholder after input media error")
+    }))
+}
+
+/// How the extraction job should finish after all items have been attempted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExtractionJobFailureKind {
+    /// Not a total failure (successes, or nothing processed).
+    None,
+    /// Every attempted item failed, all as input-media → soft complete.
+    InputMediaOnly,
+    /// Every attempted item failed, at least one non-input → hard fail.
+    Systemic,
+}
+
+/// Classifies job-wide failure from aggregate counters.
+///
+/// - Soft-fail corrupt media increments both `errors` and `input_errors`.
+/// - Inference/output failures increment only `errors`.
+/// - `input_errors` is always ≤ `errors` in normal operation.
+fn classify_extraction_job_failure(
+    processed: i64,
+    errors: i64,
+    input_errors: i64,
+) -> ExtractionJobFailureKind {
+    let all_failed = processed > 0 && errors >= processed;
+    if !all_failed {
+        return ExtractionJobFailureKind::None;
+    }
+    if input_errors == errors {
+        ExtractionJobFailureKind::InputMediaOnly
+    } else {
+        // input_errors < errors (mixed), or inconsistent input_errors > errors
+        ExtractionJobFailureKind::Systemic
+    }
+}
+
+impl JobCounters {
+    /// Apply one item's outcome to in-memory job counters (no I/O).
+    fn record_item(
+        &mut self,
+        item_type: &str,
+        segments: i64,
+        count_file: bool,
+        is_error: bool,
+        is_input_error: bool,
+    ) {
+        self.processed += 1;
+        self.total_segments += segments;
+        if count_file {
+            if item_type.starts_with("video") {
+                self.video_files += 1;
+            } else if item_type.starts_with("image") {
+                self.image_files += 1;
+            } else {
+                self.other_files += 1;
+            }
+        } else if is_error {
+            self.errors += 1;
+            if is_input_error {
+                self.input_errors += 1;
+            }
+        }
+    }
+}
+
 async fn finalize_item(
     index_db: &str,
     job_id: i64,
@@ -649,26 +864,13 @@ async fn finalize_item(
     segments: i64,
     count_file: bool,
     is_error: bool,
+    is_input_error: bool,
     counters: Arc<Mutex<JobCounters>>,
     total_remaining: i64,
 ) {
     let update = {
         let mut guard = counters.lock().await;
-        guard.processed += 1;
-        guard.total_segments += segments;
-
-        if count_file {
-            if item_type.starts_with("video") {
-                guard.video_files += 1;
-            } else if item_type.starts_with("image") {
-                guard.image_files += 1;
-            } else {
-                guard.other_files += 1;
-            }
-        } else if is_error {
-            guard.errors += 1;
-        }
-
+        guard.record_item(item_type, segments, count_file, is_error, is_input_error);
         let remaining = total_remaining.saturating_sub(guard.processed);
         DataLogUpdate {
             image_files: guard.image_files,
@@ -1226,5 +1428,295 @@ fn bind_param<'q>(
             })?;
             Ok(query.bind(encoded))
         }
+    }
+}
+
+#[cfg(test)]
+mod soft_fail_tests {
+    use super::*;
+
+    #[test]
+    fn no_items_is_not_a_failure() {
+        assert_eq!(
+            classify_extraction_job_failure(0, 0, 0),
+            ExtractionJobFailureKind::None
+        );
+    }
+
+    #[test]
+    fn partial_success_is_not_total_failure() {
+        // 3 processed, 1 error (input or not) → job completes
+        assert_eq!(
+            classify_extraction_job_failure(3, 1, 1),
+            ExtractionJobFailureKind::None
+        );
+        assert_eq!(
+            classify_extraction_job_failure(3, 1, 0),
+            ExtractionJobFailureKind::None
+        );
+    }
+
+    #[test]
+    fn all_input_media_failures_soft_complete() {
+        assert_eq!(
+            classify_extraction_job_failure(5, 5, 5),
+            ExtractionJobFailureKind::InputMediaOnly
+        );
+        assert_eq!(
+            classify_extraction_job_failure(1, 1, 1),
+            ExtractionJobFailureKind::InputMediaOnly
+        );
+    }
+
+    #[test]
+    fn any_non_input_failure_among_all_failed_is_systemic() {
+        // All failed, but one inference/output error mixed with input media
+        assert_eq!(
+            classify_extraction_job_failure(4, 4, 3),
+            ExtractionJobFailureKind::Systemic
+        );
+        // All inference failures
+        assert_eq!(
+            classify_extraction_job_failure(2, 2, 0),
+            ExtractionJobFailureKind::Systemic
+        );
+    }
+
+    #[test]
+    fn record_item_tracks_input_errors_separately() {
+        let mut c = JobCounters::default();
+        // soft-fail input media: not a "file" success, is_error + is_input_error
+        c.record_item("image/png", 0, false, true, true);
+        assert_eq!(c.processed, 1);
+        assert_eq!(c.errors, 1);
+        assert_eq!(c.input_errors, 1);
+        assert_eq!(c.image_files, 0);
+
+        // inference failure
+        c.record_item("image/jpeg", 2, false, true, false);
+        assert_eq!(c.processed, 2);
+        assert_eq!(c.errors, 2);
+        assert_eq!(c.input_errors, 1);
+        assert_eq!(c.total_segments, 2);
+
+        // successful image
+        c.record_item("image/webp", 1, true, false, false);
+        assert_eq!(c.processed, 3);
+        assert_eq!(c.errors, 2);
+        assert_eq!(c.input_errors, 1);
+        assert_eq!(c.image_files, 1);
+
+        assert_eq!(
+            classify_extraction_job_failure(c.processed, c.errors, c.input_errors),
+            ExtractionJobFailureKind::None
+        );
+    }
+
+    #[test]
+    fn all_recorded_input_errors_classify_as_soft() {
+        let mut c = JobCounters::default();
+        c.record_item("image/gif", 0, false, true, true);
+        c.record_item("image/png", 0, false, true, true);
+        assert_eq!(
+            classify_extraction_job_failure(c.processed, c.errors, c.input_errors),
+            ExtractionJobFailureKind::InputMediaOnly
+        );
+    }
+
+    #[test]
+    fn mixed_recorded_failures_classify_as_systemic() {
+        let mut c = JobCounters::default();
+        c.record_item("image/gif", 0, false, true, true);
+        c.record_item("image/png", 3, false, true, false);
+        assert_eq!(
+            classify_extraction_job_failure(c.processed, c.errors, c.input_errors),
+            ExtractionJobFailureKind::Systemic
+        );
+    }
+
+    fn tagger_model() -> ModelMetadata {
+        ModelMetadata {
+            group: "test".into(),
+            inference_id: "test-tagger".into(),
+            setter_name: "test_tagger".into(),
+            input_handler: "image_frames".into(),
+            input_handler_opts: serde_json::Map::new(),
+            target_entities: vec!["items".into()],
+            output_type: "tags".into(),
+            default_batch_size: 1,
+            default_threshold: None,
+            input_mime_types: vec!["image".into()],
+            skip_processed_items: true,
+            name: None,
+            description: None,
+            link: None,
+        }
+    }
+
+    fn next_db_name(prefix: &str) -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        format!(
+            "{prefix}_{}",
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        )
+    }
+
+    /// End-to-end soft-fail: corrupt file on disk → prepare fails as
+    /// input_media → placeholder lands in the index DB → job counters
+    /// classify as InputMediaOnly.
+    #[tokio::test]
+    async fn soft_fail_corrupt_image_writes_placeholder_row() {
+        use crate::db::migrations::migrate_databases_on_disk;
+        use crate::db::open_index_db_read_no_user_data;
+        use crate::test_utils::test_data_dir;
+        use tokio::sync::Mutex;
+
+        let _env = test_data_dir();
+        let index_db = next_db_name("softfail");
+        migrate_databases_on_disk(Some(&index_db), Some(&index_db))
+            .await
+            .expect("migrate");
+
+        let media = tempfile::TempDir::new().unwrap();
+        let bad_path = media.path().join("corrupt.png");
+        std::fs::write(&bad_path, b"not-a-real-png").unwrap();
+        let sha256 = "softfail_corrupt_sha256_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        // Item + data_jobs must exist: write_placeholder joins items/setters and
+        // item_data.job_id FKs to data_jobs.
+        let job_id = {
+            use crate::db::open_index_db_write_no_user_data;
+            let mut conn = open_index_db_write_no_user_data(&index_db)
+                .await
+                .expect("open write");
+            sqlx::query(
+                "INSERT INTO items (id, sha256, md5, type, time_added) VALUES (1, ?, 'md5', 'image/png', '2020-01-01T00:00:00')",
+            )
+            .bind(sha256)
+            .execute(&mut conn)
+            .await
+            .expect("insert item");
+            let row = sqlx::query("INSERT INTO data_jobs (completed) VALUES (0) RETURNING id")
+                .fetch_one(&mut conn)
+                .await
+                .expect("insert data_jobs");
+            use sqlx::Row;
+            row.try_get::<i64, _>("id").expect("job id")
+        };
+
+        let model = tagger_model();
+        // Production jobs upsert the setter before writing outputs.
+        call_index_db_writer(&index_db, |reply| IndexDbWriterMessage::UpsertSetter {
+            setter_name: model.setter_name.clone(),
+            reply,
+        })
+        .await
+        .expect("upsert setter");
+
+        let item = JobInputData {
+            path: bad_path.to_string_lossy().into_owned(),
+            sha256: sha256.into(),
+            item_type: "image/png".into(),
+            width: Some(64),
+            height: Some(64),
+            ..Default::default()
+        };
+
+        let prepare_err = input_handlers::prepare_item(&index_db, &model, item.clone())
+            .await
+            .expect_err("corrupt image must fail prepare");
+        assert!(
+            prepare_err.is_input_media(),
+            "prepare should be input_media, got: {}",
+            prepare_err.detail()
+        );
+
+        let counters = Arc::new(Mutex::new(JobCounters::default()));
+        soft_fail_input_media(
+            &index_db,
+            &model,
+            job_id,
+            &item.path,
+            &item.sha256,
+            &item.item_type,
+            Arc::clone(&counters),
+            /* total_remaining */ 1,
+        )
+        .await
+        .expect("placeholder write should succeed");
+
+        let guard = counters.lock().await;
+        assert_eq!(guard.processed, 1);
+        assert_eq!(guard.errors, 1);
+        assert_eq!(guard.input_errors, 1);
+        assert_eq!(
+            classify_extraction_job_failure(guard.processed, guard.errors, guard.input_errors),
+            ExtractionJobFailureKind::InputMediaOnly
+        );
+        drop(guard);
+
+        let mut conn = open_index_db_read_no_user_data(&index_db)
+            .await
+            .expect("reopen");
+        let row: (i64, i64) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*), COALESCE(SUM(is_placeholder), 0)
+            FROM item_data
+            JOIN items ON items.id = item_data.item_id
+            WHERE items.sha256 = ?
+            "#,
+        )
+        .bind(sha256)
+        .fetch_one(&mut conn)
+        .await
+        .expect("query item_data");
+        assert_eq!(row.0, 1, "expected one item_data row");
+        assert_eq!(row.1, 1, "expected is_placeholder=1");
+    }
+
+    /// When the placeholder cannot land (unknown output type → write fails),
+    /// soft_fail counts a systemic error (not input_errors) and returns Err.
+    #[tokio::test]
+    async fn soft_fail_returns_err_when_placeholder_cannot_write() {
+        use crate::db::migrations::migrate_databases_on_disk;
+        use crate::test_utils::test_data_dir;
+        use tokio::sync::Mutex;
+
+        let _env = test_data_dir();
+        let index_db = next_db_name("softfail_noph");
+        migrate_databases_on_disk(Some(&index_db), Some(&index_db))
+            .await
+            .expect("migrate");
+
+        let mut model = tagger_model();
+        model.output_type = "not-a-real-output".into();
+
+        let counters = Arc::new(Mutex::new(JobCounters::default()));
+        let err = soft_fail_input_media(
+            &index_db,
+            &model,
+            0,
+            "/tmp/x.png",
+            "no_item_sha",
+            "image/png",
+            Arc::clone(&counters),
+            1,
+        )
+        .await
+        .expect_err("placeholder must fail without a valid output type / item");
+
+        assert!(!err.detail().is_empty());
+        let guard = counters.lock().await;
+        assert_eq!(guard.processed, 1);
+        assert_eq!(guard.errors, 1);
+        assert_eq!(
+            guard.input_errors, 0,
+            "failed placeholder write must not count as input-media"
+        );
+        assert_eq!(
+            classify_extraction_job_failure(guard.processed, guard.errors, guard.input_errors),
+            ExtractionJobFailureKind::Systemic
+        );
     }
 }

--- a/panoptikon/src/jobs/extraction/input_handlers/image_frames.rs
+++ b/panoptikon/src/jobs/extraction/input_handlers/image_frames.rs
@@ -17,6 +17,7 @@ use crate::jobs::files::{FRAME_PROCESS_VERSION, stderr_tail};
 /// carry their own pixel dimensions (each page differs from the item's stored
 /// size); frames without dimensions are sliced using the item's stored
 /// width/height, mirroring the Python loader.
+#[derive(Debug)]
 pub(super) struct BaseFrame {
     pub bytes: Vec<u8>,
     pub width: Option<i64>,
@@ -73,6 +74,8 @@ pub(super) async fn build_image_frames_inputs(
             width,
             height,
             slice_settings.as_ref(),
+            &item.path,
+            &item.sha256,
         )?);
     }
     let mut outputs = Vec::new();
@@ -104,14 +107,23 @@ pub(super) async fn load_base_frames(
         }
     }
     if item.item_type.starts_with("image/gif") {
-        return gif_to_frames(&item.path);
+        return gif_to_frames(&item.path, &item.sha256);
     }
     if item.item_type.starts_with("image") {
+        // Open/read I/O is *not* input_media: soft-fail would write a permanent
+        // placeholder and skip the item after transient mount/NFS blips.
         let buffer = tokio::fs::read(&item.path).await.map_err(|err| {
-            tracing::error!(error = %err, path = %item.path, "failed to read image");
+            tracing::error!(
+                error = %err,
+                path = %item.path,
+                sha256 = %item.sha256,
+                "failed to read image"
+            );
             ApiError::internal("Failed to read image")
         })?;
-        ensure_image_readable(&buffer, &item.path)?;
+        // Full decode (not header-only): pixel-corrupt / truncated files must
+        // soft-fail as input_media before reaching coalesced inference.
+        load_dynamic_image(&buffer, &item.path, &item.sha256)?;
         return Ok(vec![BaseFrame::sized_by_item(buffer)]);
     }
     if item.item_type.starts_with("video") {
@@ -164,25 +176,7 @@ pub(super) async fn load_base_frames(
     Ok(Vec::new())
 }
 
-/// Header-level readability check mirroring Python's `is_image_readable`
-/// (PIL `verify()` with truncated images accepted): rejects files whose
-/// header cannot even be parsed, without decoding pixel data. Without this,
-/// a corrupt file reaches the inference server where it can fail an entire
-/// coalesced GPU batch instead of just this item.
-fn ensure_image_readable(buffer: &[u8], path: &str) -> ApiResult<()> {
-    image::ImageReader::new(std::io::Cursor::new(buffer))
-        .with_guessed_format()
-        .map_err(|err| {
-            tracing::error!(error = %err, path, "image format detection failed");
-            ApiError::internal(format!("Image {path} is not readable"))
-        })?
-        .into_dimensions()
-        .map_err(|err| {
-            tracing::error!(error = %err, path, "image is not readable");
-            ApiError::internal(format!("Image {path} is not readable"))
-        })?;
-    Ok(())
-}
+
 
 #[derive(Debug, Clone)]
 struct ImageSliceSettings {
@@ -244,6 +238,8 @@ fn slice_target_size(
     width: Option<i64>,
     height: Option<i64>,
     settings: Option<&ImageSliceSettings>,
+    path: &str,
+    sha256: &str,
 ) -> ApiResult<Vec<Vec<u8>>> {
     let (Some(width), Some(height), Some(settings)) = (width, height, settings) else {
         return Ok(input_images);
@@ -260,7 +256,7 @@ fn slice_target_size(
             let slices = calculate_slices_needed(width, height, settings);
             let mut output = Vec::new();
             for image in input_images {
-                output.extend(slice_image(&image, slices)?);
+                output.extend(slice_image(&image, slices, path, sha256)?);
             }
             Ok(output)
         }
@@ -271,7 +267,7 @@ fn slice_target_size(
             let (rows, cols) = grid_for_pixels(width, height, settings);
             let mut output = Vec::new();
             for image in input_images {
-                output.extend(slice_image_grid(&image, rows, cols)?);
+                output.extend(slice_image_grid(&image, rows, cols, path, sha256)?);
             }
             Ok(output)
         }
@@ -305,9 +301,14 @@ fn calculate_slices_needed(width: f64, height: f64, settings: &ImageSliceSetting
     ((image_ratio / target_ratio).ceil() as usize).max(1)
 }
 
-fn slice_image(image_bytes: &[u8], num_slices: usize) -> ApiResult<Vec<Vec<u8>>> {
+fn slice_image(
+    image_bytes: &[u8],
+    num_slices: usize,
+    path: &str,
+    sha256: &str,
+) -> ApiResult<Vec<Vec<u8>>> {
     let format = slice_output_format(image_bytes);
-    let image = load_dynamic_image(image_bytes)?;
+    let image = load_dynamic_image(image_bytes, path, sha256)?;
     let (width, height) = image.dimensions();
     let mut output = Vec::new();
     if width >= height {
@@ -372,9 +373,15 @@ fn grid_for_pixels(width: f64, height: f64, settings: &ImageSliceSettings) -> (u
     (rows, cols)
 }
 
-fn slice_image_grid(image_bytes: &[u8], rows: usize, cols: usize) -> ApiResult<Vec<Vec<u8>>> {
+fn slice_image_grid(
+    image_bytes: &[u8],
+    rows: usize,
+    cols: usize,
+    path: &str,
+    sha256: &str,
+) -> ApiResult<Vec<Vec<u8>>> {
     let format = slice_output_format(image_bytes);
-    let image = load_dynamic_image(image_bytes)?;
+    let image = load_dynamic_image(image_bytes, path, sha256)?;
     let (width, height) = image.dimensions();
     let tile_w = width as f64 / cols as f64;
     let tile_h = height as f64 / rows as f64;
@@ -392,10 +399,15 @@ fn slice_image_grid(image_bytes: &[u8], rows: usize, cols: usize) -> ApiResult<V
     Ok(output)
 }
 
-fn load_dynamic_image(buffer: &[u8]) -> ApiResult<DynamicImage> {
+fn load_dynamic_image(buffer: &[u8], path: &str, sha256: &str) -> ApiResult<DynamicImage> {
     crate::jobs::files::decode_image_bytes(buffer).map_err(|err| {
-        tracing::error!(error = %err, "failed to decode image");
-        ApiError::internal("Failed to decode image")
+        tracing::error!(
+            error = %err,
+            path,
+            sha256,
+            "failed to decode image"
+        );
+        ApiError::input_media("Failed to decode image")
     })
 }
 
@@ -417,28 +429,48 @@ fn encode_jpeg(image: &DynamicImage) -> ApiResult<Vec<u8>> {
     Ok(buffer)
 }
 
-fn gif_to_frames(path: &str) -> ApiResult<Vec<BaseFrame>> {
+fn gif_to_frames(path: &str, sha256: &str) -> ApiResult<Vec<BaseFrame>> {
+    // Open/read I/O is not soft-failed (see still-image branch above).
     let buffer = std::fs::read(path).map_err(|err| {
-        tracing::error!(error = %err, "failed to open gif");
+        tracing::error!(
+            error = %err,
+            path,
+            sha256,
+            "failed to open gif"
+        );
         ApiError::internal("Failed to open gif")
     })?;
     // Files are routed here by extension-derived mime type; a mis-named
     // non-GIF (which PIL decoded regardless of extension) is handled as a
     // single still frame instead of failing the item.
     if !matches!(image::guess_format(&buffer), Ok(image::ImageFormat::Gif)) {
-        let image = crate::jobs::files::decode_image_bytes(&buffer).map_err(|err| {
-            tracing::error!(error = %err, path, "failed to decode mis-named gif");
-            ApiError::internal("Failed to decode gif")
+        let image = load_dynamic_image(&buffer, path, sha256).map_err(|err| {
+            // load_dynamic_image already logs; normalize message for GIF path.
+            if err.is_input_media() {
+                ApiError::input_media("Failed to decode gif")
+            } else {
+                err
+            }
         })?;
         return Ok(vec![BaseFrame::sized_by_item(encode_jpeg(&image)?)]);
     }
     let decoder = GifDecoder::new(std::io::Cursor::new(&buffer)).map_err(|err| {
-        tracing::error!(error = %err, "failed to decode gif");
-        ApiError::internal("Failed to decode gif")
+        tracing::error!(
+            error = %err,
+            path,
+            sha256,
+            "failed to decode gif"
+        );
+        ApiError::input_media("Failed to decode gif")
     })?;
     let frames = decoder.into_frames().collect_frames().map_err(|err| {
-        tracing::error!(error = %err, "failed to collect gif frames");
-        ApiError::internal("Failed to decode gif")
+        tracing::error!(
+            error = %err,
+            path,
+            sha256,
+            "failed to collect gif frames"
+        );
+        ApiError::input_media("Failed to decode gif")
     })?;
     if frames.is_empty() {
         return Ok(Vec::new());
@@ -619,4 +651,68 @@ async fn render_html_frames(path: &str) -> ApiResult<Vec<BaseFrame>> {
         height: Some(shot.height() as i64),
         bytes: encode_jpeg(&shot)?,
     }])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a real 1×1 RGB PNG via the image crate (must fully decode).
+    fn tiny_png() -> Vec<u8> {
+        let img = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            1,
+            1,
+            image::Rgb([0, 0, 0]),
+        ));
+        let mut buf = Vec::new();
+        img.write_to(
+            &mut std::io::Cursor::new(&mut buf),
+            image::ImageFormat::Png,
+        )
+        .expect("encode 1x1 png");
+        buf
+    }
+
+    #[test]
+    fn readable_png_decodes() {
+        load_dynamic_image(&tiny_png(), "/tmp/ok.png", "abc").unwrap();
+    }
+
+    #[test]
+    fn garbage_bytes_are_input_media() {
+        let err = load_dynamic_image(b"not-an-image", "/tmp/bad.png", "deadbeef").unwrap_err();
+        assert!(
+            err.is_input_media(),
+            "expected input_media, got generic: {}",
+            err.detail()
+        );
+    }
+
+    #[test]
+    fn empty_buffer_is_input_media() {
+        let err = load_dynamic_image(b"", "/tmp/empty.png", "0").unwrap_err();
+        assert!(err.is_input_media());
+    }
+
+    #[test]
+    fn truncated_png_header_is_input_media() {
+        let mut buf = tiny_png();
+        buf.truncate(16);
+        let err = load_dynamic_image(&buf, "/tmp/trunc.png", "t").unwrap_err();
+        assert!(err.is_input_media());
+    }
+
+    #[test]
+    fn load_dynamic_image_marks_corrupt_as_input_media() {
+        let err = load_dynamic_image(b"GIF89a-not-really", "/tmp/x.gif", "sha").unwrap_err();
+        assert!(err.is_input_media());
+    }
+
+    #[test]
+    fn gif_missing_file_is_not_soft_fail() {
+        // Transient missing mounts must not write a permanent placeholder.
+        let err = gif_to_frames("/nonexistent/path/missing.gif", "sha").unwrap_err();
+        assert!(!err.is_input_media());
+        assert!(err.detail().contains("open") || err.detail().contains("gif"));
+    }
 }

--- a/panoptikon/src/jobs/extraction/output_handlers/mod.rs
+++ b/panoptikon/src/jobs/extraction/output_handlers/mod.rs
@@ -15,10 +15,13 @@ pub(super) enum OutputDisposition {
     Skipped,
 }
 
-/// Writes the placeholder row for an item that produced zero inputs, marking
-/// it processed. Only for the zero-input case: an *inference* response with
-/// missing outputs must go through `handle_outputs`, where it can be
-/// distinguished from this and treated as a failure.
+/// Writes an empty output row so the item is treated as processed for this
+/// model (not re-selected every cron). Used for:
+/// - zero prepared inputs (too-small image, no video frames, …)
+/// - soft-failed corrupt/unreadable source media (`ApiError::input_media`)
+///
+/// An *inference* response with missing outputs must go through
+/// `handle_outputs` instead, so it can fail the item properly.
 pub(super) async fn write_placeholder(
     index_db: &str,
     model: &ModelMetadata,

--- a/panoptikon/src/main.rs
+++ b/panoptikon/src/main.rs
@@ -15,6 +15,7 @@ mod jobs;
 mod logging;
 mod host_paths;
 mod accelerator_env;
+mod accelerator_report;
 mod media_tools;
 mod openapi;
 mod policy;
@@ -97,6 +98,10 @@ enum Command {
         #[arg(long)]
         if_needed: bool,
     },
+    /// Print the resolved inference accelerator (cpu/cuda/rocm/…) and any
+    /// GPU names. CPU is reported without warning; GPU backends warn only
+    /// when no device name can be detected.
+    Accelerator,
     /// Download and install the latest release, replacing this executable.
     /// Checks GitHub every time (ignoring the startup-check throttle).
     Update {
@@ -197,11 +202,17 @@ async fn async_main() -> anyhow::Result<()> {
             )
             .await;
         }
+        Some(Command::Accelerator) => {
+            accelerator_report::print_report(&settings);
+            return Ok(());
+        }
         Some(Command::Update { yes }) => {
             return update::run_update_command(crate::resources::VERSION, yes).await;
         }
         None => {}
     }
+
+    accelerator_report::log_report(&settings);
 
     // Server path only (Setup/Inferio/Update returned above). Fire-and-forget a
     // best-effort, throttled check for a newer release; it prints a banner if
@@ -690,6 +701,7 @@ async fn inferio_main(
         .unwrap_or(settings.server.port);
     let listen_addr = format!("{}:{}", settings.server.host, port);
     let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
+    accelerator_report::log_report(&settings);
     tracing::info!(address = %listen_addr, "inference service listening (inferio mode)");
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();


### PR DESCRIPTION
## Summary

Three product changes that improve extraction resilience, desktop update UX, and GPU/backend visibility:

### Soft-fail corrupt media
- Decode/format failures during extraction are tagged as **input media** (`ApiError::input_media`).
- Soft path writes a placeholder (one short retry) so items are not re-selected every cron run when the placeholder lands.
- Jobs complete with a warning when **every** failure is input-media (not treated as an inference outage).
- Open/read I/O stays **internal** (not soft-failed) so transient NFS/mount errors do not permanent-skip items.
- Still images are **fully decoded** before inference (not header-only) so pixel-corrupt files fail per-item instead of poisoning coalesced batches.
- If placeholder write fails after retries, the error is counted as **systemic** (cannot soft-complete a DB/write outage as “all corrupt media”).

### Desktop update restart
- After a successful update install on Unix, call `app.restart()` so control does not fall through past a non-returning restart.
- Windows path unchanged (updater/NSIS process exit behavior).

### Accelerator report
- New `panoptikon accelerator` command and startup logging of the resolved inference **backend** (`cpu` / `cuda` / `rocm`) plus optional device names.
- Resolution order: managed-venv sentinel → `PANOPTIKON_ACCELERATOR` → config / `auto` host probes.
- **CPU** is never a warning. A **GPU** backend with no device name produces a warning only.
- ROCm/`rocminfo` lists only agents with `Device Type: GPU` (host CPU marketing names are not reported as devices).

## Test plan
- [x] Soft-fail unit/integration tests (`soft_fail_*`, image_frames)
- [x] Accelerator report unit tests (including rocminfo GPU-only parsing)
- [x] Broader `cargo test -p panoptikon` / `panoptikon-config` (non-desktop)
- [x] Manual: `panoptikon accelerator` on a ROCm/CUDA host
- [x] Manual: desktop update install + relaunch on Linux

## Scope
Server/desktop Rust only. No flake, NixOS module, pin hooks, or GitHub Actions changes (see the separate packaging PR #23).