### PR TITLE
Fix desktop process restart after successful update install

### DIFF
--- a/panoptikon-desktop/src-tauri/src/updates.rs
+++ b/panoptikon-desktop/src-tauri/src/updates.rs
@@ -931,9 +931,14 @@ impl UpdateCoordinator {
             return Err(format!("Update installation failed: {error}"));
         }
         emit_progress(app, "restarting", 0, None, true);
+        // On Unix, restart replaces this process and never returns. Windows
+        // completes install without an in-process restart here.
+        #[cfg(windows)]
+        {
+            return Ok(());
+        }
         #[cfg(not(windows))]
         app.restart();
-        Ok(())
     }
 
     async fn validate_exact_install_target(


### PR DESCRIPTION
## Summary

After a successful update install on Unix, call `app.restart()` so the process is replaced instead of falling through past a non-returning restart. Windows still returns `Ok(())` after install (NSIS/updater process exit), which is unchanged.

One-file bugfix; no extraction or accelerator changes.

## Test plan
- [x] Manual: install a desktop update on Linux and confirm the app relaunches
- [ ] Confirm Windows updater path still completes install (no in-process restart expected)